### PR TITLE
Clarify Contribution

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -1,0 +1,1 @@
+Theo Belaire

--- a/license.md
+++ b/license.md
@@ -66,7 +66,7 @@ When this license requires you to contribute software:
 
 <!-- On criterion 10 of the Open Source Definition, see https://writing.kemitchell.com/2018/11/05/OSD-Copyleft-Regulation.html#technology-neutrality -->
 
-2.  License that software under the terms of this license, so the developer and others may work with that software.  Alternatively, you may license that software on other terms with substantially the same legal effect as [Copyright](#copyright), [Patent](#patent), and [Reliability](#reliability).  Your other terms may, but need not, include a rule like [Notices](#notices), a disclaimer like [Disclaimer](#disclaimer), or both, but no other terms.  For example, you may license under the [BSD-2-Clause Plus Patent License](https://spdx.org/licenses/BSD-2-Clause-Patent.html).
+2.  License new parts of that software that hasn't already been contributed under the terms of this license, so the developer and others may work with that software.  Alternatively, you may license new parts of that software on other terms with substantially the same legal effect as [Copyright](#copyright), [Patent](#patent), and [Reliability](#reliability).  Your other terms may, but need not, include a rule like [Notices](#notices), a disclaimer like [Disclaimer](#disclaimer), or both, but no other terms.  For example, you may license under the [BSD-2-Clause Plus Patent License](https://spdx.org/licenses/BSD-2-Clause-Patent.html).
 
 <!-- Note that criterion 3 of the Open Source Definition requires permitting licensing on the same terms: https://writing.kemitchell.com/2018/11/05/OSD-Copyleft-Regulation.html#allow-the-same-terms-for-derived-works -->
 


### PR DESCRIPTION
Clarify that _Contribution_ does not allow licensees to relicense the software on more permissive terms, but rather requires making new contributions available on the same or permissive terms, without changing terms for what has already been contributed.